### PR TITLE
update skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Use the package manager [pip](https://pip.pypa.io/en/stable/) to install all dep
 ```bash
 pip install -r requirements.txt
 ```
+>⚠️ Note:
+>Some dependencies, such as `cffi==1.15.0`, are not compatible with `Python 3.13+`.
+>To avoid installation errors, it's recommended to use `Python 3.9–3.11`.
 
 ## Usage
 


### PR DESCRIPTION
### PR Description

This PR completes the task in #1 by adding a note to the `README.md` in the root folder, clarifying that `Python 3.13+` may cause compatibility issues due to `cffi==1.15.0`, and recommending the use of `Python 3.9–3.11`.

No structural or functional changes were made—since the project skeleton is already provided in the original repo, this PR is focused purely on documentation clarification.