### PR TITLE
Create a general template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Use the package manager [pip](https://pip.pypa.io/en/stable/) to install all dep
 ```bash
 pip install -r requirements.txt
 ```
+>⚠️ Note:
+>Some dependencies, such as `cffi==1.15.0`, are not compatible with `Python 3.13+`.
+>To avoid installation errors, it's recommended to use `Python 3.9–3.11`.
 
 ## Usage
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,3 +9,51 @@ app = Flask(__name__)
 @app.route('/')
 def index():
     return render_template('index.html', title="MLH Fellow", url=os.getenv("URL"))
+
+
+@app.route('/profile_summary')
+def profile_summary():
+    profile_summary = {
+        "name": "Firstname Lastname",
+        "work_experiences": [
+            {
+                "position": "Job Title",
+                "company": "Company Name",
+                "start": "Jan 20XX",
+                "end": "Dec 20XX",
+                "description": "Brief description of responsibilities and achievements."
+            },
+            {
+                "position": "Another Role",
+                "company": "Another Company",
+                "start": "Feb 20XX",
+                "end": None,
+                "description": "Optional second job experience, currently ongoing."
+            }
+        ],
+        "education": [
+            {
+                "degree": "Degree Title",
+                "institution": "University Name",
+                "year": "20XX",
+                "details": "Short summary of your academic focus or projects."
+            },
+            {
+                "degree": "Another Degree",
+                "institution": "Institution Name",
+                "year": "20YY",
+                "details": "Additional academic details or thesis title."
+            }
+        ],
+        "hobbies": [
+            "Example hobby one",
+            "Example hobby two",
+            "Another sample interest"
+        ],
+        "social_links": [
+        {"platform": "GitHub", "url": "https://github.com/MLH"},
+        {"platform": "LinkedIn", "url": "https://www.linkedin.com/company/major-league-hacking/posts/?feedView=all"}
+        ]
+    }
+
+    return render_template('profile_summary.html', title="Profile Summary", profile_summary = profile_summary, url=os.getenv("URL"))

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -1,17 +1,39 @@
-p, h1, h2, h3, h4, h5, h6, button {
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+button {
     font-family: "Roboto", serif;
 }
 
 body {
     background-color: #f5f5f9;
     background-size: cover;
-    width: auto; 
+    width: auto;
     overflow-x: hidden;
     font-family: "Roboto", serif;
     margin: 0px;
 }
 
-.nav-bar {
+section {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+    font-size: 20px;
+    font-weight: 400;
+}
+
+ul {
+    list-style-type: none;
+    margin-left: -2.5rem;
+}
+
+.nav-bar,
+.footer {
+    text-align: center;
     width: 100%;
     display: inline-block;
     background-color: #1C539F;
@@ -51,25 +73,25 @@ body {
 
 .profile {
     background-color: #1d539f !important;
-    text-align: center;
     height: 320px;
     margin-bottom: 50px;
 }
 
 .profile h1 {
-        font-size: 50px;
-        font-weight: 700;
-        color: white;
+    text-align: center;
+    font-size: 50px;
+    font-weight: 700;
+    color: white;
 }
 
 .profile img {
-        border-radius: 50%;
-        max-width: 100%;
-        max-height: 100%;
-        margin-left: auto;
-        margin-right: auto;
-        display: block;        
-        padding: 20px;
+    border-radius: 50%;
+    max-width: 100%;
+    max-height: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+    padding: 20px;
 }
 
 .profile .profile-picture {
@@ -84,8 +106,8 @@ body {
 }
 
 .banner .logo {
-    max-width:180px;
-    max-height:60px;
+    max-width: 180px;
+    max-height: 60px;
     width: auto;
     height: auto;
 }
@@ -94,4 +116,9 @@ body {
     color: white;
     font-size: 50px;
     font-weight: 700;
+}
+
+.footer .footer-content {
+    color: white;
+    font-weight: 400;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,4 +37,5 @@
         <h1>{{ title }}</h1>
     </div>
 </body>
+
 </html>

--- a/app/templates/profile_summary.html
+++ b/app/templates/profile_summary.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta property="og:title" content="Personal Portfolio">
+    <meta property="og:description" content="My Personal Portfolio">
+    <meta property="og:url" content="{{ url }}">
+
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+        rel="stylesheet">
+
+    <link lang='sass' rel="stylesheet" href="./static/styles/main.css">
+    <link rel='icon' href='./static/img/favicon.ico' type='image/x-icon' />
+    <title>{{ title }}</title>
+</head>
+
+<body>
+    <header class="nav-bar">
+        <div class="nav-content">
+            <a href="/">
+                <div class="nav-logo">
+                    <img src="./static/img/logo.svg" />
+                </div>
+            </a>
+        </div>
+    </header>
+
+    <div class="profile_details">
+        <section id="experiences">
+            <h2>Work Experience</h2>
+            <ul>
+                {% for work in profile_summary.work_experiences %}
+                <li>
+                    <strong>{{ work.position }}</strong> at <em>{{ work.company }}</em> ({{ work.start }} - {{
+                    work.end
+                    or 'Present' }})
+                    <p>{{ work.description }}</p>
+                </li>
+                <br>
+                {% endfor %}
+            </ul>
+        </section>
+
+        <section id="education">
+            <h2>Education</h2>
+            <ul>
+                {% for edu in profile_summary.education %}
+                <li>
+                    <strong>{{ edu.degree }}</strong> - {{ edu.institution }} ({{ edu.year }})
+                    <p>{{ edu.details }}</p>
+                </li>
+                <br>
+                {% endfor %}
+            </ul>
+        </section>
+
+        <section id="hobbies">
+            <h2>Hobbies</h2>
+            <ul>
+                {% for hobby in profile_summary.hobbies %}
+                <li>{{ hobby }}</li>
+                {% endfor %}
+            </ul>
+        </section>
+    </div>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>© {{ current_year }} {{ profile_summary.name }}. All rights reserved.</p>
+            <p>Follow me on:
+                {% for link in profile_summary.social_links %}
+                <a href="{{ link.url }}" target="_blank">{{ link.platform }}</a>{% if not loop.last %}, {% endif %}
+                {% endfor %}
+            </p>
+        </div>
+    </footer>
+</body>
+
+</html>


### PR DESCRIPTION
### PR Description

This PR completes the task in #2 by adding a new `profile_summary.html` template to display key profile sections including **work experience**, **education**, and **hobbies**. The page reuses some structural elements and styling from the existing `index.html` and shared CSS.

The corresponding route has been registered in `__init__.py`, and the page is now accessible at: [http://127.0.0.1:5000/profile_summary]

---

### Notes
- Since the `index.html` page may later be extended to include an "About Me" section and personal photo, a separate route was created specifically for the profile summary content.

- Currently, the content is embedded directly in the route for demonstration purposes. In the future, it would be better to decouple the data and load it from a JSON file or a database.